### PR TITLE
Reword browsers compatibility warning, add link to more detailed info

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,14 +119,15 @@
 				is done while the HTML page loads.</p>
 
 			<p>
-				<mark><strong>Attention:</strong> Currently this only works in
-					Firefox 3+ and Safari 5.1+
+				<mark><strong>Attention:</strong> Currently,
+					<a href="https://caniuse.com/#feat=mathml">this only works
+					in Firefox and Safari</a>.
 				</mark>
 			</p>
 
 			<p>While HTML5 now includes MathML as an official
 				recommendation, the remaining browsers do not appear to be
-				implementing it.  For widest browser compatability, the use
+				implementing it. For widest browser compatibility, the use
 				of MathJax is recommended.</p>
 
 		</li>


### PR DESCRIPTION
Current wording may give the impression that the website wasn’t updated in a very long time.

- Remove version information, because older versions aren’t relevant anyway
- Add a link to a more detailed overview of MathML status in web browsers
- Fix a typo